### PR TITLE
amend migration notes for later steps to append orphan pages/posts

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -15,8 +15,14 @@ The old WordPress repository was archived:
 
 Process to migrate from WordPress to static files:
 
-1. Used `curl` to pull down the four pages as `.html` files
+1. Used `curl` to pull down the four visible pages as `.html` files
 2. Used `curl` to pull down missing dependencie (js, css) into relevant directory structure
 3. Used `curl` to pull down missing uploads into `wp-content/uploads/`
 4. Moved everything into `docs/`
 5. Added `docs/.nojekyll` (empty file)
+6. Discovered the site had a lot of "orphan pages" not present within the site's current nav from prior site incarnations, but still publicly accessible.
+7. Setup a temporary node environment virtual space.
+8. Used [`wordpress-to-eleventy`](https://github.com/mattl/wordpress-to-eleventy), to generate static `.html` pages, amending the default post and page templates' header and footer to pull down all the pages and posts via the site's API as new `.html` files into appropriate subdirectories.
+9. Deleted temporary node environment.
+10. Used `scp` to pull down everything from the `wp-content/uploads` folder to account for all the orphan posts/pages now added. `scp -r [name-of-ssh-alias]:path/to/wp-content/uploads path/to/local/uploads`
+


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
* amends the `migration` documentation to account for the orphan pages that were later discovered, and the second phase followup process I followed to grab them.


## Additional Context
Initially the site only had 4 public pages so setting up something complex to convert it to static seemed like overkill, given `curl` could likely do it super fast. That was done and the site seemed ready to be migrated to GH.

Then, after doing an audit of the site to ensure that the public pages on the live site matched up with all live pages within the WP interface it was discovered that the newest design reduced the number of pages down to 4, but that the prior incarnations of the site had a lot more. Additionally, those pages were still listed as public, despite no longer being located anywhere within the nav or the newer pages body. This meant anyone with an older link to these pages would still be able to view them, but the site wouldn't allow you to get there organically.

As a result I evaluated the quickest way to get the remaining pages pulled down. `wordpress-to-eleventy` seemed reasonable since I could take one of the current pages I already had, grab its header and footer, drop it into the default templates of the tool, and then with a one liner get all the remaining pages and posts.

After, I downloaded all the files from `uploads` to ensure that all the orphan pages/posts had any relevant embedded media.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
